### PR TITLE
adding browser prefix for transition

### DIFF
--- a/dist/appearlazy.css
+++ b/dist/appearlazy.css
@@ -1,6 +1,8 @@
 .appear[data-src], .appear[data-bkg], .appear [data-src], .appear [data-bkg] {
   opacity: 0;
-  transition: opacity 1s ease-in;
+  -webkit-transition: opacity 1s ease-in;
+     -moz-transition: opacity 1s ease-in;
+          transition: opacity 1s ease-in;
 }
 .appeared[data-src], .appeared[data-bkg], .appeared [data-src], .appeared [data-bkg] {
   opacity: 1;


### PR DESCRIPTION
images aren't fading in firefox. adding browser prefixes to ensure consistency.
