### PR TITLE
addEventListener requires 3 arguments

### DIFF
--- a/lib/appear.js
+++ b/lib/appear.js
@@ -17,7 +17,7 @@ appear = (function(){
       scrollLastPos = null;
     }, 30);
   }
-  addEventListener('scroll', track);
+  addEventListener('scroll', track, false);
 
   // determine if a given element (plus an additional "bounds" area around it) is in the viewport
   function viewable(el, bounds){
@@ -70,8 +70,8 @@ appear = (function(){
         doCheckAppear();
 
         // add relevant listeners
-        addEventListener('scroll', checkAppear);
-        addEventListener('resize', checkAppear);
+        addEventListener('scroll', checkAppear, false);
+        addEventListener('resize', checkAppear, false);
       }
 
       function end() {
@@ -203,7 +203,7 @@ appear = (function(){
         };
 
         // add an event listener to init when dom is ready
-        addEventListener('DOMContentLoaded', init);
+        addEventListener('DOMContentLoaded', init, false);
         // call init if document is ready to be worked with and we missed the event
         if (document.readyState === 'complete' || document.readyState === 'loaded' || document.readyState === 'interactive') {
           init();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appear",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "utility to run functions when dom elements are visible",
   "kewords": "detect viewable elements dom lazy load scroll ",
   "main": "appear.js",


### PR DESCRIPTION
addEventListener requires 3 arguments otherwise older browsers throw exceptions. 

MDN claims its optional, but required for "broad compatibility": 
https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener

Heres an example of issues happening on iPhone:
http://www.sencha.com/forum/showthread.php?139339-quot-Not-enough-arguments-quot-error-caused-by-Ext.History

Other places around the web:
https://github.com/teddyzeenny/rsvp.js/commit/1c883635bbfbb627c20fcd197e29f198e30bc970

We think we're seeing these errors in CreativeLive's New Relic Browser Dashboard. 